### PR TITLE
Master

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ It can be part of a desktop environment (DE) or be used standalone.
 
 #### OSX
 - [Spectacle](https://www.spectacleapp.com/)
+- [Mjolnir](https://github.com/sdegutis/mjolnir)
 - [Phoenix](https://github.com/kasper/phoenix)
 
 


### PR DESCRIPTION
Phoenix is technically deprecated in comparison to mjolnir for OSX. Kept phoenix, added mjolnir.